### PR TITLE
README: Shallow clone the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Here are some details about my setup:
 
 ## Download
 ```
-mkdir -p ~/Documents/git-lab && git clone https://github.com/zodd18/dotfiles.git ~/Documents/git-lab/dotfiles && cd ~/Documents/git-lab/dotfiles
+mkdir -p ~/Documents/git-lab && git clone --depth=1 https://github.com/zodd18/dotfiles.git ~/Documents/git-lab/dotfiles && cd ~/Documents/git-lab/dotfiles
 ```
 
 ## Executing the script


### PR DESCRIPTION
The repository ~1Gb in size and there is no need to clone the full history given that we will only be executing the script or copying the configs only.